### PR TITLE
bug fix for Minerva maj@1

### DIFF
--- a/lm_eval/tasks/minerva_math.py
+++ b/lm_eval/tasks/minerva_math.py
@@ -295,14 +295,12 @@ class MinervaMath(Task):
 
         assert isinstance(params, dict)
         
-        if params == {}:
+        if self.MAJORITY_VOTING not in params:
             unnormalized_answer = self.get_unnormalized_answer(candidates)
             answer = self.normalize_final_answer(unnormalized_answer)
             answers = [answer]
-        elif self.MAJORITY_VOTING in params:
-            answer, pass_rate, answers = self.majority_vote(candidates)
         else:
-            raise AssertionError
+            answer, pass_rate, answers = self.majority_vote(candidates)
 
         if self.is_equiv(
             answer, doc["answer"]
@@ -311,7 +309,7 @@ class MinervaMath(Task):
         else: 
             retval = 0
 
-        if not self.MAJORITY_VOTING:
+        if self.MAJORITY_VOTING not in params:
             pass_rate = retval
 
         results = {


### PR DESCRIPTION
When I initially implemented Minerva-style prompting, I thought that MinervaMath.MAJORITY_VOTING was a bool. It's actually a string. This PR corrects a bug caused by that misunderstanding.