### PR TITLE
Minerva refactor

### DIFF
--- a/lm_eval/tasks/math_tasks.py
+++ b/lm_eval/tasks/math_tasks.py
@@ -140,7 +140,7 @@ class SymbolicMathTask(Task, SymbolicMathMixin, MajorityVotingMixin, ABC):
             pass_rate = acc
         else:
             answers = [
-                    self.normalize_final_answer(self.get_unnormalized_answer(candidate))
+                    self.normalize_tex(self.get_unnormalized_answer(candidate))
                     for candidate in candidates
                     if self.get_unnormalized_answer(candidate) != self.INVALID_ANSWER
             ]

--- a/lm_eval/tasks/math_tasks.py
+++ b/lm_eval/tasks/math_tasks.py
@@ -1,0 +1,175 @@
+import re
+import math
+import code
+import signal
+from abc import ABC, abstractmethod
+
+import inspect
+import lm_eval.datasets.hendrycks_math.hendrycks_math
+from lm_eval.metrics import mean
+from lm_eval.base import Task, rf
+from lm_eval.utils import MajorityVotingMixin, SymbolicMathMixin
+
+class SymbolicMathTask(Task, SymbolicMathMixin, MajorityVotingMixin, ABC):
+    """
+    Abstract base class representing tasks whose answer is a LaTeX mathematical expression,
+    e.g `347`, `\sqrt{3}/3`, or `x^2 + 7`.
+
+    Note that this template inherits from `SymbolicMathMixin`. Therefore you do not need 
+    to write code for TeX expression normalization, parsing, and equivalence judgement. 
+
+    See lm_eval.tasks.minerva_math for a reference implementation.
+
+    Abstract properties:
+        has_training_docs (bool): whether task has a training set
+        has_validation_docs (bool): whether the task has a validation set
+        has_test_docs (bool): whether the task has a test set. 
+        training_docs (Iterator[Dict]): Iterator containing the training set. 
+            Each row *must* have a field named `"answer"` that contains a LaTeX expression string.
+        validation_docs (Iterator[Dict]): Iterator containing the validation set. 
+            Each row *must* have a field named `"answer"` that contains a LaTeX expression string.
+        test_docs (Iterator[Dict]): Iterator containing the test set. 
+            Each row *must* have a field named `"answer"` that contains a LaTeX expression string.
+        fewshot_context (str): context that is the model is conditioned on.
+        end_seq (str): when sampling from a model, stops sampling when `end_seq` is generated.
+        get_unnormalized_answer (str | Literal[self.INVALID_ANSWER]): extracts a TeX expression 
+            from generated text. Returns `self.INVALID_ANSWER` if extraction failed.
+
+    """
+    MAJORITY_VOTING = "majority_voting"
+    SAMPLING_TEMPERATURE = "sampling_temperature"
+    TOP_P = "top_p"
+    EVAL_BATCH_SIZE = "eval_batch_size"
+    INVALID_ANSWER="[invalidanswer]"
+
+    @abstractmethod
+    def has_training_docs(self) -> bool:
+        pass
+
+    @abstractmethod
+    def has_validation_docs(self) -> bool:
+        pass
+
+    @abstractmethod
+    def has_test_docs(self) -> bool:
+        pass
+
+    @abstractmethod
+    def training_docs(self):
+        pass
+
+    @abstractmethod
+    def validation_docs(self):
+        pass
+
+    @abstractmethod
+    def test_docs(self):
+        pass
+
+    @abstractmethod
+    def fewshot_context(self, doc):
+        """
+        Arguments:
+            doc (Dict): a dataset row. 
+        Returns:
+            out (str): Fewshot context corresponding to `doc`. 
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def end_seq(self) -> str:
+        """
+        str: Model will generate until `self.end_seq`.
+        """
+        pass
+
+    @abstractmethod
+    def get_unnormalized_answer(self, text: str) -> str:
+        """
+        Arguments:
+            text (str): model sample
+        Returns:
+            out (str): string containing a TeX Expression. 
+        """
+        pass
+
+    def doc_to_target(self):
+        raise NotImplementedError("SymbolicMathTask has no doc_to_target method.")
+
+    def doc_to_text(self, doc):
+        raise NotImplementedError("SymbolicMathTask does not implement doc_to_text")
+
+    def should_decontaminate(self):
+        return False
+
+    def construct_requests(self, doc, ctx, params={}):
+        if params == {}:
+            return rf.generate(ctx, [self.end_seq])
+        
+        majority_voting_value = int(params.get(self.MAJORITY_VOTING, 1))
+        sampling_temperature_value = float(params.get(self.SAMPLING_TEMPERATURE, 1.0))
+        top_p = float(params.get(self.TOP_P, 1.0))
+        eval_batch_size = params.get(self.EVAL_BATCH_SIZE, None)
+        eval_batch_size = int(eval_batch_size) if isinstance(eval_batch_size, str) else eval_batch_size
+        generation_params = {
+            'num_return_sequences': majority_voting_value,
+            'temperature': sampling_temperature_value,
+            'top_p': top_p,
+            'num_return_sequences_batch': eval_batch_size
+        }
+        return rf.generate(ctx, [self.end_seq], generation_params)
+
+    def process_results(self, doc, results, params={}):
+        candidates = results[0]
+
+        assert isinstance(params, dict)
+        
+        if self.MAJORITY_VOTING not in params:
+            unnormalized_answer = self.get_unnormalized_answer(candidates)
+            answer = self.normalize_tex(unnormalized_answer)
+
+            if unnormalized_answer==self.INVALID_ANSWER:
+                acc = 0
+            elif self.is_tex_equiv(answer, doc['answer']):
+                acc = 1 
+            else: 
+                acc = 0 
+
+            pass_rate = acc
+        else:
+            answers = [
+                    self.normalize_final_answer(self.get_unnormalized_answer(candidate))
+                    for candidate in candidates
+                    if self.get_unnormalized_answer(candidate) != self.INVALID_ANSWER
+            ]
+            
+            acc, pass_rate, votes = self.majority_vote(
+                    answers,
+                    correct_answer=doc['answer'],
+                    is_equiv=self.is_tex_equiv,
+            )
+            if votes:
+                answer = votes[0][0]
+            else: 
+                answer = self.INVALID_ANSWER
+
+        results = {
+            "acc": acc,
+            "pass_rate": pass_rate,
+            "metadata": {
+                "selected_answer": answer,
+                "unprocessed_answers": candidates,
+            }
+        }
+
+        if self.MAJORITY_VOTING in params:
+            results["metadata"]["votes"] = votes
+
+        return results
+
+    def aggregation(self):
+        return {"acc": mean, "pass_rate": mean}
+
+    def higher_is_better(self):
+        return {"acc": True, "pass_rate": True}

--- a/lm_eval/tasks/math_tasks.py
+++ b/lm_eval/tasks/math_tasks.py
@@ -34,7 +34,6 @@ class SymbolicMathTask(Task, SymbolicMathMixin, MajorityVotingMixin, ABC):
         end_seq (str): when sampling from a model, stops sampling when `end_seq` is generated.
         get_unnormalized_answer (str | Literal[self.INVALID_ANSWER]): extracts a TeX expression 
             from generated text. Returns `self.INVALID_ANSWER` if extraction failed.
-
     """
     MAJORITY_VOTING = "majority_voting"
     SAMPLING_TEMPERATURE = "sampling_temperature"
@@ -90,7 +89,8 @@ class SymbolicMathTask(Task, SymbolicMathMixin, MajorityVotingMixin, ABC):
         Arguments:
             text (str): model sample
         Returns:
-            out (str): string containing a TeX Expression. 
+            out (str | Literal[self.INVALID_ANSWER]): string containing a TeX Expression or 
+                `self.INVALID_ANSWER`. 
         """
         pass
 

--- a/lm_eval/tasks/math_tasks.py
+++ b/lm_eval/tasks/math_tasks.py
@@ -30,10 +30,11 @@ class SymbolicMathTask(Task, SymbolicMathMixin, MajorityVotingMixin, ABC):
             Each row *must* have a field named `"answer"` that contains a LaTeX expression string.
         test_docs (Iterator[Dict]): Iterator containing the test set. 
             Each row *must* have a field named `"answer"` that contains a LaTeX expression string.
-        fewshot_context (str): context that is the model is conditioned on.
+        fewshot_context (str): context that the model will be conditioned on. Should include few shot examples
+            and the test example.
         end_seq (str): when sampling from a model, stops sampling when `end_seq` is generated.
         get_unnormalized_answer (str | Literal[self.INVALID_ANSWER]): extracts a TeX expression 
-            from generated text. Returns `self.INVALID_ANSWER` if extraction failed.
+            from a model sample. Returns `self.INVALID_ANSWER` if extraction failed.
     """
     MAJORITY_VOTING = "majority_voting"
     SAMPLING_TEMPERATURE = "sampling_temperature"

--- a/lm_eval/tasks/minerva_math.py
+++ b/lm_eval/tasks/minerva_math.py
@@ -243,7 +243,10 @@ class MinervaMath(Task, SymbolicMathMixin, MajorityVotingMixin):
                     correct_answer=doc['answer'],
                     is_equiv=self.is_tex_equiv,
             )
-            answer = votes[0][0]
+            if votes:
+                answer = votes[0][0]
+            else: 
+                answer = self.INVALID_ANSWER
 
         results = {
             "acc": acc,

--- a/lm_eval/tasks/minerva_math.py
+++ b/lm_eval/tasks/minerva_math.py
@@ -22,7 +22,7 @@ import lm_eval.datasets.hendrycks_math.hendrycks_math
 from lm_eval.metrics import mean
 from lm_eval.base import Task, rf
 
-PROMPT=r"""Problem:
+NL_PROMPT=r"""Problem:
 Find the domain of the expression  $\frac{\sqrt{x-2}}{\sqrt{5-x}}$.}
 
 Solution:
@@ -101,6 +101,7 @@ class MinervaMath(Task):
     TOP_P = "top_p"
     EVAL_BATCH_SIZE = "eval_batch_size"
     INVALID_ANSWER="[invalidanswer]"
+    PROMPT = NL_PROMPT
 
     end_seq = "I hope it is correct."
 
@@ -208,7 +209,7 @@ class MinervaMath(Task):
             self, doc, num_fewshot, provide_description=None, rnd=None, description=None
     ):
         example = self.doc_to_text(doc)
-        prompt = PROMPT + "\n\n" + example
+        prompt = self.PROMPT + "\n\n" + example
 
         return prompt
 

--- a/lm_eval/tasks/minerva_math.py
+++ b/lm_eval/tasks/minerva_math.py
@@ -21,6 +21,8 @@ import inspect
 import lm_eval.datasets.hendrycks_math.hendrycks_math
 from lm_eval.metrics import mean
 from lm_eval.base import Task, rf
+from lm_eval.utils import SymbolicMathMixin
+
 
 NL_PROMPT=r"""Problem:
 Find the domain of the expression  $\frac{\sqrt{x-2}}{\sqrt{5-x}}$.}
@@ -81,19 +83,8 @@ _CITATION = """
       primaryClass={cs.CL}
 }
 """
-class timeout:
-    def __init__(self, seconds=1, error_message='Timeout'):
-        self.seconds = seconds
-        self.error_message = error_message
-    def handle_timeout(self, signum, frame):
-        raise TimeoutError(self.error_message)
-    def __enter__(self):
-        signal.signal(signal.SIGALRM, self.handle_timeout)
-        signal.alarm(self.seconds)
-    def __exit__(self, type, value, traceback):
-        signal.alarm(0)
 
-class MinervaMath(Task):
+class MinervaMath(Task, SymbolicMathMixin):
     DATASET_PATH = inspect.getfile(lm_eval.datasets.hendrycks_math.hendrycks_math)
     DATASET_NAME = None
     MAJORITY_VOTING = "majority_voting"
@@ -174,7 +165,7 @@ class MinervaMath(Task):
         return s[len(left) : -1]
 
     def _process_doc(self, doc):
-        doc["answer"] = self.normalize_final_answer(
+        doc["answer"] = self.normalize_tex(
                 self.remove_boxed(self.last_boxed_only_string(doc["solution"]))
         )
         return doc
@@ -224,40 +215,6 @@ class MinervaMath(Task):
         else:
             return self.INVALID_ANSWER
 
-    def is_equiv(self, x1: str, x2: str):
-        """
-        x1 and x2 are normalized latex string
-        """
-        try: 
-            with timeout(seconds=5):
-                try:
-                    parsed_x1 = parse_latex(x1)
-                    parsed_x2 = parse_latex(x2)
-                except (sympy.parsing.latex.errors.LaTeXParsingError, sympy.SympifyError, TypeError):
-                    print(f"couldn't parse one of {x1} or {x2}")
-                    return False
-            
-                try: 
-                    diff = parsed_x1 - parsed_x2
-                except TypeError:
-                    print(f"couldn't subtract {x1} and {x2}")
-                    return False
-
-                try:
-                    if sympy.simplify(diff)==0:
-                        return True
-                    else: 
-                        return False
-                except ValueError:
-                    print(f"Had some trouble simplifying when comparing {x1} and {x2}")
-        except TimeoutError:
-            print(f"Timed out comparing {x1} and {x2}")
-            return False
-        except Exception as e: 
-            print(f"Failed comparing {x1} and {x2} with {e}")
-            return False
-
-
     def majority_vote(self, candidates):
 
         # get and normalize all answers
@@ -277,7 +234,7 @@ class MinervaMath(Task):
             else:
                 counted = False
                 for ref in answer_votes:
-                    if self.is_equiv(answer, ref) and not counted:
+                    if self.is_tex_equiv(answer, ref) and not counted:
                         answer_votes[ref] += 1
                         counted=True
 
@@ -301,12 +258,12 @@ class MinervaMath(Task):
         
         if self.MAJORITY_VOTING not in params:
             unnormalized_answer = self.get_unnormalized_answer(candidates)
-            answer = self.normalize_final_answer(unnormalized_answer)
+            answer = self.normalize_tex(unnormalized_answer)
             answers = [answer]
         else:
             answer, pass_rate, answers = self.majority_vote(candidates)
-
-        if self.is_equiv(
+        
+        if self.is_tex_equiv(
             answer, doc["answer"]
         ):
             retval = 1
@@ -333,60 +290,6 @@ class MinervaMath(Task):
 
     def higher_is_better(self):
         return {"acc": True, "pass_rate": True, "log_pass_rate": mean}
-
-    SUBSTITUTIONS = [
-        ('an ', ''), ('a ', ''), ('.$', '$'), ('\\$', ''), (r'\ ', ''), 
-        (' ', ''), ('mbox', 'text'), (',\\text{and}', ','), 
-        ('\\text{and}', ','), ('\\text{m}', '\\text{}')
-    ]
-    REMOVED_EXPRESSIONS = [
-        'square', 'ways', 'integers', 'dollars', 'mph', 'inches', 'ft', 
-        'hours', 'km', 'units', '\\ldots', 'sue', 'points', 'feet', 
-        'minutes', 'digits', 'cents', 'degrees', 'cm', 'gm', 'pounds', 
-        'meters', 'meals', 'edges', 'students', 'childrentickets', 'multiples',
-        '\\text{s}', '\\text{.}', '\\text{\ns}', '\\text{}^2', 
-        '\\text{}^3', '\\text{\n}', '\\text{}', r'\mathrm{th}', 
-        r'^\circ', r'^{\circ}', r'\;', r',\!', '{,}', '"', '\\dots'
-    ]
-
-    def normalize_final_answer(self, final_answer: str) -> str:
-      """
-      Normalize a final answer to a quantitative reasoning question.
-
-      Copied character for character from appendix D of Lewkowycz et al. (2022)
-      """
-      final_answer = final_answer.split('=')[-1]
-      
-      for before, after in self.SUBSTITUTIONS:
-        final_answer = final_answer.replace(before, after)
-      for expr in self.REMOVED_EXPRESSIONS:
-        final_answer = final_answer.replace(expr, '')
-      
-      # Extract answer that is in LaTeX math, is bold, 
-      # is surrounded by a box, etc.  
-      final_answer = re.sub(r'(.*?)(\$)(.*?)(\$)(.*)', '$\\3$', final_answer)
-      final_answer = re.sub(r'(\\text\{)(.*?)(\})', '\\2', final_answer)
-      final_answer = re.sub(r'(\\textbf\{)(.*?)(\})', '\\2', final_answer)
-      final_answer = re.sub(r'(\\overline\{)(.*?)(\})', '\\2', final_answer)
-      final_answer = re.sub(r'(\\boxed\{)(.*)(\})', '\\2', final_answer)
-      
-      # Normalize shorthand TeX:
-      #  \fracab -> \frac{a}{b}
-      #  \frac{abc}{bef} -> \frac{abc}{bef}
-      #  \fracabc -> \frac{a}{b}c
-      #  \sqrta -> \sqrt{a}
-      #  \sqrtab -> sqrt{a}b
-      final_answer = re.sub(
-        r'(frac)([^{])(.)', 'frac{\\2}{\\3}', final_answer)
-      final_answer = re.sub(
-        r'(sqrt)([^{])', 'sqrt{\\2}', final_answer)
-      final_answer = final_answer.replace('$', '')
-      
-      # Normalize 100,000 -> 100000
-      if final_answer.replace(',', '').isdigit():
-        final_answer = final_answer.replace(',', '')
-        
-      return final_answer
 
 
 class MinervaMathAlgebraEasy(MinervaMath):

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -80,7 +80,7 @@ class MajorityVotingMixin:
                 if not counted: 
                     answer_votes[answer] = 1
 
-        votes = list(sorted(answer_votes.items(), key=lambda x: x[1]))
+        votes = list(sorted(answer_votes.items(), key=lambda x: -x[1]))
 
         elected_answer = votes[0][0]
 
@@ -90,8 +90,8 @@ class MajorityVotingMixin:
         else:
             acc = 0
             pass_rate = 0
-            for candidate, num_votes in votes.items():
-                if is_equiv(correct_answer, elected_answer):
+            for candidate, num_votes in answer_votes.items():
+                if is_equiv(correct_answer, candidate):
                     pass_rate = num_votes / len(sampled_answers)
                     break
 
@@ -209,7 +209,7 @@ class SymbolicMathMixin:
             sympy.SympifyError,
             TypeError,
         ) as e:
-            print(f"failed to parse {text} with familiar exception {e}")
+            print(f"failed to parse {text} with exception {e}")
             return None
 
         return parsed
@@ -222,18 +222,20 @@ class SymbolicMathMixin:
             with timeout(seconds=time_limit):
                 try:
                     diff = x1 - x2
-                    try:
-                        if sympy.simplify(diff) == 0:
-                            return True
-                        else:
-                            return False
-                    except ValueError as e:
-                        print(f"Failed to simplify {x1}-{x2} with {e}")
-                        return False
                 except TypeError as e:
                     print(
-                        f"Couldn't subtract {x1} and {x2} with familiar exception {e}"
+                        f"Couldn't subtract {x1} and {x2} with exception {e}"
                     )
+                    return False
+
+                try:
+                    if sympy.simplify(diff) == 0:
+                        return True
+                    else:
+                        return False
+                except ValueError as e:
+                    print(f"Failed to simplify {x1}-{x2} with {e}")
+                    return False
         except TimeoutError as e:
             print(f"Timed out comparing {x1} and {x2}")
             return False


### PR DESCRIPTION
Factors out reusable components from the `MinervaMath` implementation into reusabale ABCs and mixins. 

- `MajorityVotingMixin` implements majority voting. 
- `SymbolicMathMixin` implements functions for parsing TeX expressions from strings and determing sympy equivalence of expressions.
- `SymbolicMathTask` is a template for implementing tasks whose answer is a mathematical expression. 

I plan to write follow up PRs that create a `NumericalMathTask`. The harness implements a template for multiple choice tasks, but we may have to modify it for our use case. 