### PR TITLE
Identify_math_theorems task

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -59,6 +59,7 @@ from . import crowspairs
 from . import lila
 from . import proofnet
 from . import hendrycks_test_cot
+from . import identify_math_theorems
 
 ########################################
 # Translation tasks
@@ -394,6 +395,7 @@ TASK_REGISTRY = {
     "proofnet_autoformalize_statements": proofnet.ProofNetAutoformalizeStatements,
     "proofnet_informalize_statements": proofnet.ProofNetInformalizeStatements,
     **hendrycks_test_cot.create_all_mcqa_tasks(),
+    "identify_math_theorems": identify_math_theorems.IdentifyMathThms,
     #
     # Requires manual download of data.
     # "storycloze_2016": storycloze.StoryCloze2016,

--- a/lm_eval/tasks/identify_math_theorems.py
+++ b/lm_eval/tasks/identify_math_theorems.py
@@ -135,17 +135,6 @@ class IdentifyMathThms(MultipleChoiceTask):
             "gold": doc["multiple_choice_scores"].index(1),
         }
 
-    def fewshot_examples(self, k, rnd):
-        # fewshot_examples is not just sampling from train_docs because dev is
-        # in the same distribution as val/test but auxiliary_train isn't
-
-        if self._fewshot_docs is None:
-            self._fewshot_docs = list(map(self._process_doc, self.dataset["dev"]))
-
-        # use the unchanged order of the dev set without sampling,
-        # just as in the original code https://github.com/hendrycks/test/blob/master/evaluate.py#L28
-        return self._fewshot_docs[:k]
-
     def doc_to_text(self, doc):
         return doc["query"]
 

--- a/lm_eval/tasks/identify_math_theorems.py
+++ b/lm_eval/tasks/identify_math_theorems.py
@@ -1,0 +1,156 @@
+"""
+Measuring Massive Multitask Language Understanding
+https://arxiv.org/pdf/2009.03300.pdf
+
+The Hendryck's Test is a benchmark that measured a text model’s multitask accuracy.
+The test covers 57 tasks including elementary mathematics, US history, computer
+science, law, and more. To attain high accuracy on this test, models must possess
+extensive world knowledge and problem solving ability. By comprehensively evaluating
+the breadth and depth of a model’s academic and professional understanding,
+Hendryck's Test can be used to analyze models across many tasks and to identify
+important shortcomings.
+
+Homepage: https://github.com/hendrycks/test
+"""
+from lm_eval.base import MultipleChoiceTask
+
+
+_CITATION = """
+@article{hendryckstest2021,
+    title={Measuring Massive Multitask Language Understanding},
+    author={Dan Hendrycks and Collin Burns and Steven Basart and Andy Zou and Mantas Mazeika and Dawn Song and Jacob Steinhardt},
+    journal={Proceedings of the International Conference on Learning Representations (ICLR)},
+    year={2021}
+}
+"""
+
+
+SUBJECTS = [
+    "abstract_algebra",
+    "anatomy",
+    "astronomy",
+    "business_ethics",
+    "clinical_knowledge",
+    "college_biology",
+    "college_chemistry",
+    "college_computer_science",
+    "college_mathematics",
+    "college_medicine",
+    "college_physics",
+    "computer_security",
+    "conceptual_physics",
+    "econometrics",
+    "electrical_engineering",
+    "elementary_mathematics",
+    "formal_logic",
+    "global_facts",
+    "high_school_biology",
+    "high_school_chemistry",
+    "high_school_computer_science",
+    "high_school_european_history",
+    "high_school_geography",
+    "high_school_government_and_politics",
+    "high_school_macroeconomics",
+    "high_school_mathematics",
+    "high_school_microeconomics",
+    "high_school_physics",
+    "high_school_psychology",
+    "high_school_statistics",
+    "high_school_us_history",
+    "high_school_world_history",
+    "human_aging",
+    "human_sexuality",
+    "international_law",
+    "jurisprudence",
+    "logical_fallacies",
+    "machine_learning",
+    "management",
+    "marketing",
+    "medical_genetics",
+    "miscellaneous",
+    "moral_disputes",
+    "moral_scenarios",
+    "nutrition",
+    "philosophy",
+    "prehistory",
+    "professional_accounting",
+    "professional_law",
+    "professional_medicine",
+    "professional_psychology",
+    "public_relations",
+    "security_studies",
+    "sociology",
+    "us_foreign_policy",
+    "virology",
+    "world_religions",
+]
+
+
+
+class IdentifyMathThms(MultipleChoiceTask):
+    VERSION = 1
+    DATASET_PATH = "bigbench"
+    DATASET_NAME = "identify_math_theorems"
+
+    def has_training_docs(self):
+        return False
+
+    def has_validation_docs(self):
+        return False
+
+    def has_test_docs(self):
+        return True
+
+    def test_docs(self):
+        return map(self._process_doc, self.dataset["default"])
+
+    def fewshot_context(self, doc, num_fewshot, **kwargs):
+        subject = self.DATASET_NAME
+        description = "What follows is a purported mathematical theorem. Some will be true, while other will be false. If the theorem is correct, write the theorem exactly as it is given. Otherwise, write a corrected version of the theorem. Write all answeres in compilable LaTeX."
+        kwargs["description"] = description
+        return super().fewshot_context(doc=doc, num_fewshot=num_fewshot, **kwargs)
+
+    def _process_doc(self, doc):
+        def format_example(doc, keys):
+            """
+            <prompt>
+            
+            A. <choice1>
+            B. <choice2>
+            C. <choice3>
+            D. <choice4>
+            Answer:
+            """
+            question = doc["inputs"].strip()
+            choices = "".join(
+                [f"{key}. {choice}\n" for key, choice in zip(keys, doc["multiple_choice_targets"])]
+            )
+            prompt = f"{question}\n{choices}Answer:"
+            return prompt
+
+        keys = ["A", "B", "C", "D"]
+        return {
+            "query": format_example(doc, keys),
+            "choices": doc["multiple_choice_targets"], # keys,
+            "gold": doc["multiple_choice_scores"].index(1),
+        }
+
+    def fewshot_examples(self, k, rnd):
+        # fewshot_examples is not just sampling from train_docs because dev is
+        # in the same distribution as val/test but auxiliary_train isn't
+
+        if self._fewshot_docs is None:
+            self._fewshot_docs = list(map(self._process_doc, self.dataset["dev"]))
+
+        # use the unchanged order of the dev set without sampling,
+        # just as in the original code https://github.com/hendrycks/test/blob/master/evaluate.py#L28
+        return self._fewshot_docs[:k]
+
+    def doc_to_text(self, doc):
+        return doc["query"]
+
+    def should_decontaminate(self):
+        return True
+
+    def doc_to_decontamination_query(self, doc):
+        return doc["query"]

--- a/lm_eval/tasks/identify_math_theorems.py
+++ b/lm_eval/tasks/identify_math_theorems.py
@@ -131,7 +131,7 @@ class IdentifyMathThms(MultipleChoiceTask):
         keys = ["A", "B", "C", "D"]
         return {
             "query": format_example(doc, keys),
-            "choices": doc["multiple_choice_targets"], # keys,
+            "choices": doc["multiple_choice_targets"], # use `keys` to use letter labels
             "gold": doc["multiple_choice_scores"].index(1),
         }
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         "transformers>=4.1",
         "zstandard",
         "accelerate",
-        "timeout_decorator"
+        "timeout_decorator",
         "bigbench @ https://storage.googleapis.com/public_research_data/bigbench/bigbench-0.0.1.tar.gz"
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setuptools.setup(
         "zstandard",
         "accelerate",
         "timeout_decorator"
+        "bigbench @ https://storage.googleapis.com/public_research_data/bigbench/bigbench-0.0.1.tar.gz"
     ],
     extras_require={
         "dev": ["black", "flake8", "pre-commit", "pytest", "pytest-cov"],


### PR DESCRIPTION
At least zero-shot, should be equivalent to reported BIG-Bench paper results.
```
hf-causal (pretrained=codellama/CodeLlama-7b-hf), limit: None, provide_description: False, num_fewshot: 0, batch_size: None
|         Task         |Version| Metric |Value |   |Stderr|
|----------------------|------:|--------|-----:|---|-----:|
|identify_math_theorems|      1|acc     |0.4340|±  |0.0687|
|                      |       |acc_norm|0.3962|±  |0.0678|
```

Versus palm-8b scores: https://github.com/google/BIG-bench/blob/6436ed17f979b138463224421f8e8977b89076ed/bigbench/benchmark_tasks/identify_math_theorems/results/scores_PaLM_8b.json#L7