### PR TITLE
MammothTemplateMixin + Some fixes to Identify_math_theorems

### DIFF
--- a/lm_eval/mixins.py
+++ b/lm_eval/mixins.py
@@ -280,7 +280,6 @@ class MammothTemplateMixin:
             kwargs["description"] = self.TEMPLATE_NO_DESCRIPTION
 
         ctx = super().fewshot_context(*args, **kwargs)
-        print(ctx)
         return ctx
 
     def doc_to_template(self, doc, doc_to_text): # doc_to_text should be from task's original doc_to_text

--- a/lm_eval/mixins.py
+++ b/lm_eval/mixins.py
@@ -260,3 +260,33 @@ class SymbolicMathMixin:
         Determines whether two (ideally normalized using `normalize_text`) TeX expressions are equal.
         """
         return self.is_exp_equiv(self.parse_tex(x1), self.parse_tex(x2), time_limit=time_limit)
+
+
+class MammothTemplateMixin:
+    """
+    Wraps a task's prompt in Alpaca-style instruction templates following MAmmoTH.
+    """
+    TEMPLATE = "Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request."
+
+    TEMPLATE_NO_DESCRIPTION = "Below is an instruction that describes a task. Write a response that appropriately completes the request."
+
+    USE_INPUT: bool = False # 
+
+    def fewshot_context(self, *args, **kwargs):
+
+        if "description" in kwargs:
+            kwargs["description"] = self.TEMPLATE + "\n\n### Instruction:\n" + kwargs["description"]
+            self.USE_INPUT = True
+        else:
+            kwargs["description"] = self.TEMPLATE_NO_DESCRIPTION
+
+        ctx = super().fewshot_context(*args, **kwargs)
+        print(ctx)
+        return ctx
+
+    def doc_to_template(self, doc, doc_to_text): # doc_to_text should be from task's original doc_to_text
+        print("using templated doc_to_text")
+        if self.USE_INPUT: 
+            return f"### Input:\n" + f"{doc_to_text}\n\n### Response:"
+        else:
+            return f"### Instruction:\n" + f"{doc_to_text}\n\n### Response:"

--- a/lm_eval/mixins.py
+++ b/lm_eval/mixins.py
@@ -273,7 +273,6 @@ class MammothTemplateMixin:
     USE_INPUT: bool = False # 
 
     def fewshot_context(self, *args, **kwargs):
-
         if "description" in kwargs:
             kwargs["description"] = self.TEMPLATE + "\n\n### Instruction:\n" + kwargs["description"]
             self.USE_INPUT = True
@@ -285,7 +284,6 @@ class MammothTemplateMixin:
         return ctx
 
     def doc_to_template(self, doc, doc_to_text): # doc_to_text should be from task's original doc_to_text
-        print("using templated doc_to_text")
         if self.USE_INPUT: 
             return f"### Input:\n" + f"{doc_to_text}\n\n### Response:"
         else:

--- a/lm_eval/mixins.py
+++ b/lm_eval/mixins.py
@@ -280,6 +280,7 @@ class MammothTemplateMixin:
             kwargs["description"] = self.TEMPLATE_NO_DESCRIPTION
 
         ctx = super().fewshot_context(*args, **kwargs)
+        print(ctx)
         return ctx
 
     def doc_to_template(self, doc, doc_to_text): # doc_to_text should be from task's original doc_to_text

--- a/lm_eval/tasks/identify_math_theorems.py
+++ b/lm_eval/tasks/identify_math_theorems.py
@@ -88,7 +88,7 @@ SUBJECTS = [
 
 
 
-class IdentifyMathThms(MammothTemplateMixin, MultipleChoiceTask):
+class IdentifyMathThms(MultipleChoiceTask):
     VERSION = 1
     DATASET_PATH = "bigbench"
     DATASET_NAME = "identify_math_theorems"

--- a/lm_eval/tasks/identify_math_theorems.py
+++ b/lm_eval/tasks/identify_math_theorems.py
@@ -13,6 +13,7 @@ important shortcomings.
 Homepage: https://github.com/hendrycks/test
 """
 from lm_eval.base import MultipleChoiceTask
+from lm_eval.mixins import MammothTemplateMixin
 
 
 _CITATION = """
@@ -87,7 +88,7 @@ SUBJECTS = [
 
 
 
-class IdentifyMathThms(MultipleChoiceTask):
+class IdentifyMathThms(MammothTemplateMixin, MultipleChoiceTask):
     VERSION = 1
     DATASET_PATH = "bigbench"
     DATASET_NAME = "identify_math_theorems"
@@ -121,7 +122,7 @@ class IdentifyMathThms(MultipleChoiceTask):
             D. <choice4>
             Answer:
             """
-            question = doc["inputs"].strip()
+            question = doc["inputs"].strip().lstrip("What follows is a purported mathematical theorem. Some will be true, while other will be false. If the theorem is correct, write the theorem exactly as it is given. Otherwise, write a corrected version of the theorem. Write all answeres in compilable LaTeX.\n\n")
             choices = "".join(
                 [f"{key}. {choice}\n" for key, choice in zip(keys, doc["multiple_choice_targets"])]
             )
@@ -136,6 +137,8 @@ class IdentifyMathThms(MultipleChoiceTask):
         }
 
     def doc_to_text(self, doc):
+        if hasattr(self, "doc_to_template"):
+            return self.doc_to_template(doc, doc["query"]) # args to doc_to_template are (doc, doc_to_text)
         return doc["query"]
 
     def should_decontaminate(self):


### PR DESCRIPTION
This PR adds `MammothTemplateMixin`, which can be used to apply the first template prompt from MAmmoTH here: https://github.com/TIGER-AI-Lab/MAmmoTH/blob/602da3df96f0dffdc092dcb1c8bf3ceef2f5eaf1/utils.py#L57 either with or without the separate `### Input` field (when using a description, this is used.)

The changes required to apply this to a task are:
- add the `MammothTemplateMixin` to 
- modify `MyTask.doc_to_text()` to apply `doc_to_template` instead following the example in this PR.

**Note that the ordering left-to-right of inheritance matters here. This mixin should come prior to other, in order to use its `fewshot_context` method which then calls to super()'s fewshot_context in the correct order.**

This PR also fixes identify_math_theorems somewhat, because it turns out that the official bigbench dataset loading script does preprocessing I didn't anticipate (namely, it had already added the description, which for this feature we do not want).